### PR TITLE
Added IP whitelist support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ Leave `PROXY_USER` and `PROXY_PASSWORD` empty for skip authentication options wh
 |PROXY_PASSWORD|String|EMPTY|Set proxy password for auth, used with PROXY_USER|
 |PROXY_PORT|String|1080|Set listen port for application inside docker container|
 |TZ|String|UTC|Set Timezone like in many common Operation Systems|
+|ALLOWED_IPS|String|Empty|Set allowed IP's that can connect to proxy, separator `,`|
+
+`ALLOWED_IPS` parameter is not included in `serjs/go-socks5-proxy` image.\
+You can build your image with:
+`docker-compose -f docker-compose.build.yml up -d`\
+Just don't forget to set parameters in the `.env` file.
 
 ## Test running service
 

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -1,0 +1,11 @@
+version: '3'
+services:
+  socks5-build:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: socks5-build
+    env_file: .env
+    ports:
+      - "1080:1080"
+    restart: unless-stopped

--- a/server.go
+++ b/server.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"log"
+	"net"
 	"os"
 
 	"github.com/armon/go-socks5"
@@ -9,9 +10,10 @@ import (
 )
 
 type params struct {
-	User     string `env:"PROXY_USER" envDefault:""`
-	Password string `env:"PROXY_PASSWORD" envDefault:""`
-	Port     string `env:"PROXY_PORT" envDefault:"1080"`
+	User       string   `env:"PROXY_USER" envDefault:""`
+	Password   string   `env:"PROXY_PASSWORD" envDefault:""`
+	Port       string   `env:"PROXY_PORT" envDefault:"1080"`
+	AllowedIPs []string `env:"ALLOWED_IPS" envSeparator:"," envDefault:""`
 }
 
 func main() {
@@ -38,6 +40,15 @@ func main() {
 	server, err := socks5.New(socsk5conf)
 	if err != nil {
 		log.Fatal(err)
+	}
+
+	// Set IP whitelist
+	if len(cfg.AllowedIPs) > 0 {
+		whitelist := make([]net.IP, len(cfg.AllowedIPs))
+		for i, ip := range cfg.AllowedIPs {
+			whitelist[i] = net.ParseIP(ip)
+		}
+		server.SetIPWhitelist(whitelist)
 	}
 
 	log.Printf("Start listening proxy service on port %s\n", cfg.Port)

--- a/vendor/github.com/armon/go-socks5/socks5.go
+++ b/vendor/github.com/armon/go-socks5/socks5.go
@@ -55,6 +55,7 @@ type Config struct {
 type Server struct {
 	config      *Config
 	authMethods map[uint8]Authenticator
+	isIPAllowed func(net.IP) bool
 }
 
 // New creates a new Server and potentially returns an error
@@ -93,6 +94,11 @@ func New(conf *Config) (*Server, error) {
 		server.authMethods[a.GetCode()] = a
 	}
 
+	// Set default IP whitelist function
+	server.isIPAllowed = func(ip net.IP) bool {
+		return true // default allow all IPs
+	}
+
 	return server, nil
 }
 
@@ -117,10 +123,36 @@ func (s *Server) Serve(l net.Listener) error {
 	return nil
 }
 
+// SetIPWhitelist sets the function to check if a given IP is allowed
+func (s *Server) SetIPWhitelist(allowedIPs []net.IP) {
+	s.isIPAllowed = func(ip net.IP) bool {
+		for _, allowedIP := range allowedIPs {
+			if ip.Equal(allowedIP) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
 // ServeConn is used to serve a single connection.
 func (s *Server) ServeConn(conn net.Conn) error {
 	defer conn.Close()
 	bufConn := bufio.NewReader(conn)
+
+	// Check client IP against whitelist
+	clientIP, _, err := net.SplitHostPort(conn.RemoteAddr().String())
+	if err != nil {
+		s.config.Logger.Printf("[ERR] socks: Failed to get client IP address: %v", err)
+		return err
+	}
+	ip := net.ParseIP(clientIP)
+	if s.isIPAllowed(ip) {
+		s.config.Logger.Printf("[INFO] socks: Connection from allowed IP address: %s", clientIP)
+	} else {
+		s.config.Logger.Printf("[WARN] socks: Connection from not allowed IP address: %s", clientIP)
+		return fmt.Errorf("connection from not allowed IP address")
+	}
 
 	// Read the version byte
 	version := []byte{0}


### PR DESCRIPTION
This pull request adds the ability to set an IP whitelist for the socks5 proxy server. 
The `SetIPWhitelist` method has been added to the `socks5.Server` struct (`armon/go-socks5`). This feature is being used in `server.go`, allowing users to specify a list of allowed IP addresses. Any incoming connection from an IP address that is not in the whitelist will be rejected. 
Also `docker-compose.build.yml` was added to build an image from the source code.