### PR TITLE
allow restriction of destination ip address

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Simple socks5 server using go-socks5 with authentication, allowed ips list and d
 |PROXY_USER|String|EMPTY|Set proxy user (also required existed PROXY_PASS)|
 |PROXY_PASSWORD|String|EMPTY|Set proxy password for auth, used with PROXY_USER|
 |PROXY_PORT|String|1080|Set listen port for application inside docker container|
-|ALLOWED_DEST_FQDN|String|EMPTY|Allowed destination address regular expression pattern. Default allows all.|
+|ALLOWED_DEST_FQDN|String|EMPTY|Allowed destination address regular expression pattern. Default allows all. Examples "(192.168.0.1|go.dev)"|
 |ALLOWED_IPS|String|Empty|Set allowed IP's that can connect to proxy, separator `,`|
 
 

--- a/ruleset.go
+++ b/ruleset.go
@@ -19,6 +19,13 @@ type PermitDestAddrPatternRuleSet struct {
 }
 
 func (p *PermitDestAddrPatternRuleSet) Allow(ctx context.Context, req *socks5.Request) (context.Context, bool) {
-	match, _ := regexp.MatchString(p.AllowedFqdnPattern, req.DestAddr.FQDN)
-	return ctx, match
+    var match bool
+    if req.DestAddr.FQDN != nil {
+        match, _ = regexp.MatchString(p.AllowedFqdnPattern, *req.DestAddr.FQDN)
+    } else if req.DestAddr.IP != nil {
+        match, _ = regexp.MatchString(p.AllowedFqdnPattern, *req.DestAddr.IP)
+    } else {
+	match = true
+    }
+    return ctx, match
 }


### PR DESCRIPTION
See https://github.com/serjs/socks5-server/issues/49

We no longer throw an error if we connect to IP address while a 
`ALLOWED_DEST_FQDN` is set, instead we check that the destination IP address matches the pattern. This is the simplest possible change that allows users to restrict which IP addresses can be connected to. A more elaborate change would be to introduce a new environment variable that reflects that both IP addresses and domain names can be restricted. I don't mind either solution.