### PR TITLE
feat: multiple user/password authentication

### DIFF
--- a/credentials.go
+++ b/credentials.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"encoding/json"
+
+	"github.com/armon/go-socks5"
+)
+
+type credentials struct {
+	username string `json:"username"`
+	password string `json:"password"`
+}
+
+func parseCredentials(credsString string) (socks5.StaticCredentials, error) {
+	var creds []credentials
+	err := json.Unmarshal([]byte(credsString), &creds)
+	if err != nil {
+		return nil, err
+	}
+
+	var credsMap socks5.StaticCredentials
+	for _, cred := range creds {
+		credsMap[cred.username] = cred.password
+	}
+
+	return credsMap, nil
+}

--- a/credentials.go
+++ b/credentials.go
@@ -7,8 +7,8 @@ import (
 )
 
 type credentials struct {
-	username string `json:"username"`
-	password string `json:"password"`
+	Username string `json:"username"`
+	Password string `json:"password"`
 }
 
 func parseCredentials(credsString string) (socks5.StaticCredentials, error) {
@@ -20,7 +20,7 @@ func parseCredentials(credsString string) (socks5.StaticCredentials, error) {
 
 	var credsMap socks5.StaticCredentials
 	for _, cred := range creds {
-		credsMap[cred.username] = cred.password
+		credsMap[cred.Username] = cred.Password
 	}
 
 	return credsMap, nil


### PR DESCRIPTION
Allows user to provide multiple user/password objects as a JSON object via the `PROXY_CREDENTIALS` environment variable. 

```json
[
	{ "username": "username1", "password": "password123" },
	{ "username": "username2", "password": "password456" }
]
```

Recommended to squoosh your JSON so that it's easier to copy and paste into a command prompt. You can also provide a `.env` file via the [`--env-file`](https://docs.docker.com/engine/reference/commandline/run/#env) flag which makes providing this JSON object a little easier. 

I am unsure if this is the best way to pass credentials, but given the string-only limitations of environment variables, this is the best I could think of. 

fixes: https://github.com/serjs/socks5-server/issues/4