### PR TITLE
Add Built-in Health Check Support

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,9 +1,22 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [Unreleased - available on :latest tag for docker image]
-### Changed
+## [Unreleased]
+
 ### Added
+- Added built-in health check functionality via `--healthcheck` flag for Docker and monitoring systems.
+- Health check performs full SOCKS5 handshake with automatic authentication support.
+- Health check supports both authenticated (`REQUIRE_AUTH=true`) and non-authenticated modes.
+
+### Changed
+- Health check now uses the same SOCKS5 port for verification instead of requiring a separate HTTP endpoint.
+- Code formatting improved with `gofmt`.
+
+### Technical Details
+- Health check establishes TCP connection to SOCKS5 port and performs protocol handshake.
+- Automatically detects server authentication requirements and authenticates using `PROXY_USER` and `PROXY_PASSWORD`.
+- Eliminates spurious error logs during health check operations.
+- Compatible with docker-compose healthcheck configuration.
 
 ## [v0.0.4] - 2025-10-07
 

--- a/README.md
+++ b/README.md
@@ -22,9 +22,37 @@ Simple socks5 server using go-socks5 with authentication, allowed ips list and d
 |PROXY_USER|String|EMPTY|Set proxy user (also required existed PROXY_PASS)|
 |PROXY_PASSWORD|String|EMPTY|Set proxy password for auth, used with PROXY_USER|
 |PROXY_PORT|String|1080|Set listen port for application inside docker container|
+|PROXY_LISTEN_IP|String|0.0.0.0|Set listen IP for application inside docker container|
 |ALLOWED_DEST_FQDN|String|EMPTY|Allowed destination address regular expression pattern. Default allows all.|
 |ALLOWED_IPS|String|Empty|Set allowed IP's that can connect to proxy, separator `,`|
 
+# Health Check
+
+The application includes built-in health check functionality via the `--healthcheck` flag. This performs a full SOCKS5 protocol handshake to verify the server is running and accepting connections.
+
+## Usage
+
+**Docker Compose:**
+```yaml
+services:
+  socks5-proxy:
+    image: serjs/go-socks5-proxy
+    healthcheck:
+      test: ["/app/socks5", "--healthcheck"]
+      interval: 30s
+      timeout: 3s
+      retries: 3
+      start_period: 10s
+```
+
+## How it works
+
+- Connects to the SOCKS5 port and performs protocol handshake
+- Automatically detects if authentication is required
+- Uses `PROXY_USER` and `PROXY_PASSWORD` environment variables for authentication
+- Returns exit code 0 (success) or 1 (failure)
+- Works with both authenticated (`REQUIRE_AUTH=true`) and non-authenticated modes
+- No additional ports or HTTP endpoints required
 
 # Build your own image:
 `docker-compose -f docker-compose.build.yml up -d`\

--- a/server.go
+++ b/server.go
@@ -2,22 +2,22 @@ package main
 
 import (
 	"fmt"
+	"github.com/armon/go-socks5"
+	"github.com/caarlos0/env/v6"
 	"log"
 	"net"
 	"os"
 	"time"
-	"github.com/armon/go-socks5"
-	"github.com/caarlos0/env/v6"
 )
 
 type params struct {
-	User            string    `env:"PROXY_USER" envDefault:""`
-	Password        string    `env:"PROXY_PASSWORD" envDefault:""`
-	Port            string    `env:"PROXY_PORT" envDefault:"1080"`
-	AllowedDestFqdn string    `env:"ALLOWED_DEST_FQDN" envDefault:""`
-	AllowedIPs      []string  `env:"ALLOWED_IPS" envSeparator:"," envDefault:""`
-	ListenIP 		string 	  `env:"PROXY_LISTEN_IP" envDefault:"0.0.0.0"`
-	RequireAuth		bool      `env:"REQUIRE_AUTH" envDefault:"true"`
+	User            string   `env:"PROXY_USER" envDefault:""`
+	Password        string   `env:"PROXY_PASSWORD" envDefault:""`
+	Port            string   `env:"PROXY_PORT" envDefault:"1080"`
+	AllowedDestFqdn string   `env:"ALLOWED_DEST_FQDN" envDefault:""`
+	AllowedIPs      []string `env:"ALLOWED_IPS" envSeparator:"," envDefault:""`
+	ListenIP        string   `env:"PROXY_LISTEN_IP" envDefault:"0.0.0.0"`
+	RequireAuth     bool     `env:"REQUIRE_AUTH" envDefault:"true"`
 }
 
 func main() {


### PR DESCRIPTION
Adds native health check functionality to the SOCKS5 proxy server, enabling seamless integration with Docker health checks and monitoring systems.

## Changes

### Added
- **`--healthcheck` flag** - Built-in health check command that can be invoked directly from the binary
- **Full SOCKS5 protocol handshake** - Performs proper SOCKS5 greeting and authentication
- **Automatic authentication detection** - Supports both authenticated and non-authenticated modes
- **Docker Compose integration** - Ready-to-use health check configuration

### Technical Implementation
- Health check connects to the SOCKS5 port and performs protocol handshake
- Offers both no-auth (0x00) and username/password (0x02) authentication methods
- Automatically authenticates using `PROXY_USER` and `PROXY_PASSWORD` environment variables when required
- Returns exit code 0 (success) or 1 (failure) for easy integration with monitoring tools

### Benefits
- ✅ No additional HTTP endpoint or port required
- ✅ No spurious errors in server logs during health checks
- ✅ Works with both `REQUIRE_AUTH=true` and `REQUIRE_AUTH=false`
- ✅ Simple Docker health check: `test: ["/app/socks5", "--healthcheck"]`
- ✅ Native Go implementation with no external dependencies

## Usage

**Standalone:**
```bash
./socks5 --healthcheck
```

**Docker Compose:**
```yaml
healthcheck:
  test: ["/app/socks5", "--healthcheck"]
  interval: 30s
  timeout: 3s
  retries: 3
  start_period: 10s
```

## Additional Changes
- Code formatting with `gofmt`
- Add docs to README.md(also added forgot info about PROXY_LISTEN_IP)
- Added CHANGELOG.md entry